### PR TITLE
10 feature 미팅룸 정보 조회 및 미팅룸 참여자 정보조회 기능 구현

### DIFF
--- a/src/main/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomController.java
+++ b/src/main/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomController.java
@@ -3,6 +3,7 @@ package com.ssafy.ssafy_project.room.adapter.in.web;
 import com.ssafy.ssafy_project.room.adapter.in.web.dto.request.CreateRoomRequest;
 import com.ssafy.ssafy_project.room.adapter.in.web.dto.request.UpdateRoomRequest;
 import com.ssafy.ssafy_project.room.adapter.in.web.dto.response.CreateRoomResponse;
+import com.ssafy.ssafy_project.room.adapter.in.web.dto.response.GetRoomResponse;
 import com.ssafy.ssafy_project.room.adapter.in.web.dto.response.UpdateRoomResponse;
 import com.ssafy.ssafy_project.room.application.port.in.*;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ public class RoomController {
     private final CreateRoomPortIn createRoomPortIn;
     private final UpdateRoomPortIn updateRoomPortIn;
     private final DeleteRoomPortIn deleteRoomPortIn;
+    private final GetRoomPortIn getRoomPortIn;
 
     @PostMapping
     public ResponseEntity<CreateRoomResponse> createRoom(
@@ -59,5 +61,22 @@ public class RoomController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
+    @GetMapping("/{roomCode}")
+    public ResponseEntity<GetRoomResponse> getRoom(
+            @PathVariable String roomCode
+    ){
+        GetRoomCommand getRoomCommand = new GetRoomCommand(roomCode);
+        GetRoomResult getRoomResult = getRoomPortIn.getRoom(getRoomCommand);
+
+        GetRoomResponse getRoomResponse = new GetRoomResponse(
+                getRoomResult.roomId(),
+                getRoomResult.title(),
+                getRoomResult.status(),
+                getRoomResult.hostId(),
+                getRoomResult.createdTime()
+        );
+
+        return ResponseEntity.ok(getRoomResponse);
+    }
 
 }

--- a/src/main/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomController.java
+++ b/src/main/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomController.java
@@ -58,4 +58,6 @@ public class RoomController {
         deleteRoomPortIn.deleteRoom(deleteRoomCommand);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
+
+
 }

--- a/src/main/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomParticipationController.java
+++ b/src/main/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomParticipationController.java
@@ -25,14 +25,16 @@ public class RoomParticipationController {
         return ResponseEntity.ok(joinRoomResult);
     }
 
-    @PostMapping("/{roomCode}/leave")
+    @PostMapping("/{roomId}/leave")
     public ResponseEntity<Void> leaveRoom(
-            @PathVariable String roomCode,
+            @PathVariable Long roomId,
             @AuthenticationPrincipal Long userId
     ){
-        LeaveRoomCommand leaveRoomCommand = new LeaveRoomCommand(roomCode, userId);
+        LeaveRoomCommand leaveRoomCommand = new LeaveRoomCommand(roomId, userId);
         leaveRoomPortIn.leaveRoom(leaveRoomCommand);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
+
+    @GetMapping("/{roomCode}/")
 
 }

--- a/src/main/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomParticipationController.java
+++ b/src/main/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomParticipationController.java
@@ -1,5 +1,7 @@
 package com.ssafy.ssafy_project.room.adapter.in.web;
 
+import com.ssafy.ssafy_project.roomparticipant.adapter.in.web.dto.response.ParticipantResponse;
+import com.ssafy.ssafy_project.roomparticipant.adapter.in.web.dto.response.ParticipantsResponse;
 import com.ssafy.ssafy_project.roomparticipant.application.port.in.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -7,12 +9,15 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/rooms")
 public class RoomParticipationController {
     private final SaveRoomParticipantPortIn saveRoomParticipantPortIn;
     private final LeaveRoomPortIn leaveRoomPortIn;
+    private final GetParticipantsPortIn getParticipantsPortIn;
 
     @PostMapping("/{roomCode}/join")
     public ResponseEntity<JoinRoomResult> joinRoom(
@@ -35,7 +40,25 @@ public class RoomParticipationController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
+    @GetMapping("/{roomId}/participants")
+    public ResponseEntity<ParticipantsResponse> getParticipants(
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal Long loginUserId
+    ){
+        GetParticipantsCommand getParticipantsCommand = new GetParticipantsCommand(roomId, loginUserId);
 
+        List<ParticipantResponse> participantResponses = getParticipantsPortIn.getParticipants(getParticipantsCommand)
+                .stream()
+                .map(gpr->new ParticipantResponse(
+                        gpr.id(),
+                        gpr.email(),
+                        gpr.nickname(),
+                        gpr.name()
+                ))
+                .toList();
+        ParticipantsResponse participantsResponse = new ParticipantsResponse(participantResponses);
+        return ResponseEntity.ok(participantsResponse);
+    }
 
 
 }

--- a/src/main/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomParticipationController.java
+++ b/src/main/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomParticipationController.java
@@ -35,6 +35,7 @@ public class RoomParticipationController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    @GetMapping("/{roomCode}/")
+
+
 
 }

--- a/src/main/java/com/ssafy/ssafy_project/room/adapter/in/web/dto/response/GetRoomResponse.java
+++ b/src/main/java/com/ssafy/ssafy_project/room/adapter/in/web/dto/response/GetRoomResponse.java
@@ -1,0 +1,14 @@
+package com.ssafy.ssafy_project.room.adapter.in.web.dto.response;
+
+import com.ssafy.ssafy_project.room.domain.RoomStatus;
+
+import java.time.LocalDateTime;
+
+public record GetRoomResponse(
+        Long roomId,
+        String title,
+        RoomStatus status,
+        Long hostId,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/ssafy/ssafy_project/room/application/port/in/GetRoomCommand.java
+++ b/src/main/java/com/ssafy/ssafy_project/room/application/port/in/GetRoomCommand.java
@@ -1,0 +1,6 @@
+package com.ssafy.ssafy_project.room.application.port.in;
+
+public record GetRoomCommand(
+        String roomCode
+) {
+}

--- a/src/main/java/com/ssafy/ssafy_project/room/application/port/in/GetRoomPortIn.java
+++ b/src/main/java/com/ssafy/ssafy_project/room/application/port/in/GetRoomPortIn.java
@@ -1,0 +1,6 @@
+package com.ssafy.ssafy_project.room.application.port.in;
+
+public interface GetRoomPortIn {
+
+    GetRoomResult getRoom(GetRoomCommand getRoomCommand);
+}

--- a/src/main/java/com/ssafy/ssafy_project/room/application/port/in/GetRoomResult.java
+++ b/src/main/java/com/ssafy/ssafy_project/room/application/port/in/GetRoomResult.java
@@ -1,0 +1,15 @@
+package com.ssafy.ssafy_project.room.application.port.in;
+
+import com.ssafy.ssafy_project.room.domain.RoomStatus;
+
+import java.time.LocalDateTime;
+
+public record GetRoomResult(
+        Long roomId,
+        String title,
+        RoomStatus status,
+        Long hostId,
+        LocalDateTime createdTime
+
+) {
+}

--- a/src/main/java/com/ssafy/ssafy_project/room/application/service/RoomService.java
+++ b/src/main/java/com/ssafy/ssafy_project/room/application/service/RoomService.java
@@ -18,12 +18,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class RoomService implements CreateRoomPortIn, UpdateRoomPortIn, DeleteRoomPortIn {
+public class RoomService implements CreateRoomPortIn, UpdateRoomPortIn,
+        DeleteRoomPortIn, GetRoomPortIn {
 
     private final SaveRoomPortOut saveRoomPortOut;
     private final UpdateRoomPortOut updateRoomPortOut;
@@ -86,5 +88,18 @@ public class RoomService implements CreateRoomPortIn, UpdateRoomPortIn, DeleteRo
         }
 
         roomTerminationProcessor.terminate(room);
+    }
+
+    @Override
+    public GetRoomResult getRoom(GetRoomCommand getRoomCommand) {
+        String roomCode = getRoomCommand.roomCode();
+        Room room = loadRoomPortOut.loadByRoomCode(roomCode);
+        return new GetRoomResult(
+                room.getId(),
+                room.getTitle(),
+                room.getStatus(),
+                room.getHostId(),
+                room.getCreatedAt()
+        );
     }
 }

--- a/src/main/java/com/ssafy/ssafy_project/room/application/service/RoomService.java
+++ b/src/main/java/com/ssafy/ssafy_project/room/application/service/RoomService.java
@@ -94,6 +94,10 @@ public class RoomService implements CreateRoomPortIn, UpdateRoomPortIn,
     public GetRoomResult getRoom(GetRoomCommand getRoomCommand) {
         String roomCode = getRoomCommand.roomCode();
         Room room = loadRoomPortOut.loadByRoomCode(roomCode);
+        if(room.getStatus().equals(RoomStatus.ENDED)){
+            throw new RuntimeException("종료된 방입니다.");
+        }
+
         return new GetRoomResult(
                 room.getId(),
                 room.getTitle(),

--- a/src/main/java/com/ssafy/ssafy_project/roomparticipant/adapter/in/web/dto/response/ParticipantResponse.java
+++ b/src/main/java/com/ssafy/ssafy_project/roomparticipant/adapter/in/web/dto/response/ParticipantResponse.java
@@ -1,0 +1,9 @@
+package com.ssafy.ssafy_project.roomparticipant.adapter.in.web.dto.response;
+
+public record ParticipantResponse(
+        Long userId,
+        String email,
+        String nickname,
+        String name
+) {
+}

--- a/src/main/java/com/ssafy/ssafy_project/roomparticipant/adapter/in/web/dto/response/ParticipantsResponse.java
+++ b/src/main/java/com/ssafy/ssafy_project/roomparticipant/adapter/in/web/dto/response/ParticipantsResponse.java
@@ -1,0 +1,8 @@
+package com.ssafy.ssafy_project.roomparticipant.adapter.in.web.dto.response;
+
+import java.util.List;
+
+public record ParticipantsResponse(
+        List<ParticipantResponse> users
+) {
+}

--- a/src/main/java/com/ssafy/ssafy_project/roomparticipant/adapter/out/persistence/RoomParticipantJpaAdapter.java
+++ b/src/main/java/com/ssafy/ssafy_project/roomparticipant/adapter/out/persistence/RoomParticipantJpaAdapter.java
@@ -19,7 +19,8 @@ import java.util.Optional;
 @Component
 @RequiredArgsConstructor
 public class RoomParticipantJpaAdapter implements SaveRoomParticipantPortOut, FindRoomParticipantPortOut,
-        LoadActiveRoomParticipantPortOut, SaveRoomParticipantsPortOut {
+        LoadActiveRoomParticipantPortOut, SaveRoomParticipantsPortOut,
+        LoadParticipantsPortOut {
     private final RoomParticipantJpaRepository roomParticipantJpaRepository;
     private final UserJpaRepository userJpaRepository;
     private final RoomJpaRepository roomJpaRepository;
@@ -125,5 +126,86 @@ public class RoomParticipantJpaAdapter implements SaveRoomParticipantPortOut, Fi
                                 r.getCreatedTime(),
                                 r.isActive()
                         ));
+    }
+
+    @Override
+    public Optional<RoomParticipant> findByRoom_IdAndUser_IdAndIsActiveTrue(Long roomId, Long userId) {
+
+        RoomJpaEntity roomJpaEntity = roomJpaRepository.findById(roomId)
+                .orElseThrow(()-> new RuntimeException("방을 찾을 수 없습니다."));
+        Room room = new Room(
+                roomJpaEntity.getId(),
+                roomJpaEntity.getTitle(),
+                roomJpaEntity.getUserJpaEntity().getId(),
+                roomJpaEntity.getRoomCode(),
+                roomJpaEntity.getStatus(),
+                roomJpaEntity.getEndedTime(),
+                roomJpaEntity.getCreatedTime()
+        );
+
+        UserJpaEntity userJpaEntity = userJpaRepository.findById(userId)
+                .orElseThrow(()-> new RuntimeException("유저를 찾을 수 없습니다."));
+        User user = new User(
+                userJpaEntity.getId(),
+                userJpaEntity.getEmail(),
+                userJpaEntity.getPassword(),
+                userJpaEntity.getRole(),
+                userJpaEntity.getNickname(),
+                userJpaEntity.getName(),
+                userJpaEntity.getProfileImageUrl(),
+                userJpaEntity.isDeleted()
+        );
+        return roomParticipantJpaRepository.findByRoomJpaEntity_IdAndUserJpaEntity_IdAndIsActiveTrue(roomId, userId)
+                .map(r -> new RoomParticipant(
+                        r.getId(),
+                        room,
+                        user,
+                        r.getRole(),
+                        r.getJoinedTime(),
+                        r.getDurationTime(),
+                        r.getCreatedTime(),
+                        r.isActive()
+                ));
+    }
+
+    @Override
+    public List<RoomParticipant> loadAllByRoomIdAndIsActiveTrue(Long roomId) {
+        RoomJpaEntity roomJpaEntity = roomJpaRepository.findById(roomId)
+                .orElseThrow(()-> new RuntimeException("방을 찾을 수 없습니다."));
+        Room room = new Room(
+                roomJpaEntity.getId(),
+                roomJpaEntity.getTitle(),
+                roomJpaEntity.getUserJpaEntity().getId(),
+                roomJpaEntity.getRoomCode(),
+                roomJpaEntity.getStatus(),
+                roomJpaEntity.getEndedTime(),
+                roomJpaEntity.getCreatedTime()
+        );
+
+        return roomParticipantJpaRepository.findAllByRoomJpaEntity_IdAndIsActiveTrue(roomId)
+                .stream()
+                .map(r->{
+                    User user = new User(
+                            r.getUserJpaEntity().getId(),
+                            r.getUserJpaEntity().getEmail(),
+                            r.getUserJpaEntity().getPassword(),
+                            r.getUserJpaEntity().getRole(),
+                            r.getUserJpaEntity().getNickname(),
+                            r.getUserJpaEntity().getName(),
+                            r.getUserJpaEntity().getProfileImageUrl(),
+                            r.getUserJpaEntity().isDeleted()
+                    );
+                    return new RoomParticipant(
+                            r.getId(),
+                            room,
+                            user,
+                            r.getRole(),
+                            r.getJoinedTime(),
+                            r.getDurationTime(),
+                            r.getCreatedTime(),
+                            r.isActive()
+                    );
+                })
+                .toList();
     }
 }

--- a/src/main/java/com/ssafy/ssafy_project/roomparticipant/adapter/out/persistence/RoomParticipantJpaAdapter.java
+++ b/src/main/java/com/ssafy/ssafy_project/roomparticipant/adapter/out/persistence/RoomParticipantJpaAdapter.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
-public class RoomParticipantJpaAdaptor implements SaveRoomParticipantPortOut, FindRoomParticipantPortOut,
+public class RoomParticipantJpaAdapter implements SaveRoomParticipantPortOut, FindRoomParticipantPortOut,
         LoadActiveRoomParticipantPortOut, SaveRoomParticipantsPortOut {
     private final RoomParticipantJpaRepository roomParticipantJpaRepository;
     private final UserJpaRepository userJpaRepository;

--- a/src/main/java/com/ssafy/ssafy_project/roomparticipant/adapter/out/persistence/repository/RoomParticipantJpaRepository.java
+++ b/src/main/java/com/ssafy/ssafy_project/roomparticipant/adapter/out/persistence/repository/RoomParticipantJpaRepository.java
@@ -16,4 +16,6 @@ public interface RoomParticipantJpaRepository extends JpaRepository<RoomParticip
     List<RoomParticipantJpaEntity> findAllByRoomJpaEntity_IdAndIsActiveTrue(Long roomId);
 
     Optional<RoomParticipantJpaEntity> findByRoomJpaEntity_IdAndUserJpaEntity_IdAndIsActiveTrue(Long id, Long id1);
+
+    List<RoomParticipantJpaEntity> findAllByRoomJpaEntity_IdAndUserJpaEntity_Id(Long roomId, Long userId);
 }

--- a/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/port/in/GetParticipantsCommand.java
+++ b/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/port/in/GetParticipantsCommand.java
@@ -1,0 +1,7 @@
+package com.ssafy.ssafy_project.roomparticipant.application.port.in;
+
+public record GetParticipantsCommand(
+        Long roomId,
+        Long userId
+) {
+}

--- a/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/port/in/GetParticipantsPortIn.java
+++ b/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/port/in/GetParticipantsPortIn.java
@@ -1,0 +1,7 @@
+package com.ssafy.ssafy_project.roomparticipant.application.port.in;
+
+import java.util.List;
+
+public interface GetParticipantsPortIn {
+    List<GetParticipantsResult> getParticipants(GetParticipantsCommand getParticipantsCommand);
+}

--- a/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/port/in/GetParticipantsResult.java
+++ b/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/port/in/GetParticipantsResult.java
@@ -1,0 +1,9 @@
+package com.ssafy.ssafy_project.roomparticipant.application.port.in;
+
+public record GetParticipantsResult(
+        Long id,
+        String email,
+        String nickname,
+        String name
+) {
+}

--- a/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/port/in/LeaveRoomCommand.java
+++ b/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/port/in/LeaveRoomCommand.java
@@ -1,7 +1,7 @@
 package com.ssafy.ssafy_project.roomparticipant.application.port.in;
 
 public record LeaveRoomCommand(
-        String roomCode,
+        Long roomId,
         Long userId
 ) {
 }

--- a/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/port/out/FindRoomParticipantPortOut.java
+++ b/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/port/out/FindRoomParticipantPortOut.java
@@ -10,4 +10,6 @@ public interface FindRoomParticipantPortOut {
     Optional<RoomParticipant> findByRoomAndUser(Room room, User user);
 
     Optional<RoomParticipant> findByRoomAndUserAndIsActiveTrue(Room room, User user);
+
+    Optional<RoomParticipant> findByRoom_IdAndUser_IdAndIsActiveTrue(Long roomId, Long userId);
 }

--- a/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/port/out/LoadParticipantsPortOut.java
+++ b/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/port/out/LoadParticipantsPortOut.java
@@ -1,0 +1,9 @@
+package com.ssafy.ssafy_project.roomparticipant.application.port.out;
+
+import com.ssafy.ssafy_project.roomparticipant.domain.RoomParticipant;
+
+import java.util.List;
+
+public interface LoadParticipantsPortOut {
+    List<RoomParticipant> loadAllByRoomIdAndIsActiveTrue(Long roomId);
+}

--- a/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/service/RoomParticipantService.java
+++ b/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/service/RoomParticipantService.java
@@ -3,8 +3,10 @@ package com.ssafy.ssafy_project.roomparticipant.application.service;
 import com.ssafy.ssafy_project.room.application.port.out.LoadRoomPortOut;
 import com.ssafy.ssafy_project.room.application.service.RoomTerminationProcessor;
 import com.ssafy.ssafy_project.room.domain.Room;
+import com.ssafy.ssafy_project.roomparticipant.application.port.in.GetParticipantsResult;
 import com.ssafy.ssafy_project.roomparticipant.application.port.in.*;
 import com.ssafy.ssafy_project.roomparticipant.application.port.out.FindRoomParticipantPortOut;
+import com.ssafy.ssafy_project.roomparticipant.application.port.out.LoadParticipantsPortOut;
 import com.ssafy.ssafy_project.roomparticipant.application.port.out.SaveRoomParticipantPortOut;
 import com.ssafy.ssafy_project.roomparticipant.domain.RoomParticipant;
 import com.ssafy.ssafy_project.roomparticipant.domain.RoomParticipantRole;
@@ -14,17 +16,20 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class RoomParticipantService implements SaveRoomParticipantPortIn, LeaveRoomPortIn {
+public class RoomParticipantService implements SaveRoomParticipantPortIn, LeaveRoomPortIn,
+        GetParticipantsPortIn{
     private final SaveRoomParticipantPortOut saveRoomParticipantPortOut;
     private final LoadRoomPortOut loadRoomPortOut;
     private final LoadUserPortOut loadUserPortOut;
     private final FindRoomParticipantPortOut findRoomParticipantPortOut;
     private final RoomTerminationProcessor roomTerminationProcessor;
+    private final LoadParticipantsPortOut loadParticipantsPortOut;
 
     @Transactional
     @Override
@@ -78,5 +83,29 @@ public class RoomParticipantService implements SaveRoomParticipantPortIn, LeaveR
         if(found.isEmpty()){
             throw new RuntimeException("방의 참가자가 아닙니다.");
         }
+    }
+
+    @Override
+    public List<GetParticipantsResult> getParticipants(GetParticipantsCommand getParticipantsCommand) {
+        Long roomId = getParticipantsCommand.roomId();
+        Long loginUserId = getParticipantsCommand.userId();
+        Optional<RoomParticipant> found = findRoomParticipantPortOut.findByRoom_IdAndUser_IdAndIsActiveTrue(roomId, loginUserId);
+        List<GetParticipantsResult> getParticipantsResults = List.of();
+        if(found.isPresent()){
+            getParticipantsResults =  loadParticipantsPortOut.loadAllByRoomIdAndIsActiveTrue(roomId)
+                    .stream()
+                    .map(rp->new GetParticipantsResult(
+                            rp.getUser().getId(),
+                            rp.getUser().getEmail(),
+                            rp.getUser().getNickname(),
+                            rp.getUser().getName()
+                    ))
+                    .toList();
+        }
+        if(found.isEmpty()){
+            throw new RuntimeException("방의 참가자만 다른 참가자들을 조회할 수 있습니다.");
+        }
+
+        return getParticipantsResults;
     }
 }

--- a/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/service/RoomParticipantService.java
+++ b/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/service/RoomParticipantService.java
@@ -3,6 +3,7 @@ package com.ssafy.ssafy_project.roomparticipant.application.service;
 import com.ssafy.ssafy_project.room.application.port.out.LoadRoomPortOut;
 import com.ssafy.ssafy_project.room.application.service.RoomTerminationProcessor;
 import com.ssafy.ssafy_project.room.domain.Room;
+import com.ssafy.ssafy_project.room.domain.RoomStatus;
 import com.ssafy.ssafy_project.roomparticipant.application.port.in.GetParticipantsResult;
 import com.ssafy.ssafy_project.roomparticipant.application.port.in.*;
 import com.ssafy.ssafy_project.roomparticipant.application.port.out.FindRoomParticipantPortOut;
@@ -36,6 +37,11 @@ public class RoomParticipantService implements SaveRoomParticipantPortIn, LeaveR
     public JoinRoomResult saveRoomParticipant(JoinRoomCommand joinRoomCommand) {
         String roomCode = joinRoomCommand.roomCode();
         Room room = loadRoomPortOut.loadByRoomCode(roomCode);
+
+        if(room.getStatus().equals(RoomStatus.ENDED)){
+            throw new RuntimeException("이미 종료된 방입니다.");
+        }
+
 
         Long userId = joinRoomCommand.userId();
         User user = loadUserPortOut.loadById(userId);

--- a/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/service/RoomParticipantService.java
+++ b/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/service/RoomParticipantService.java
@@ -57,8 +57,8 @@ public class RoomParticipantService implements SaveRoomParticipantPortIn, LeaveR
     @Transactional
     @Override
     public void leaveRoom(LeaveRoomCommand leaveRoomCommand) {
-        String roomCode = leaveRoomCommand.roomCode();
-        Room room = loadRoomPortOut.loadByRoomCode(roomCode);
+        Long roomId = leaveRoomCommand.roomId();
+        Room room = loadRoomPortOut.loadById(roomId);
 
         Long userId = leaveRoomCommand.userId();
         User user = loadUserPortOut.loadById(userId);

--- a/src/test/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomControllerIntegrationTest.java
+++ b/src/test/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomControllerIntegrationTest.java
@@ -13,6 +13,7 @@ import org.springframework.http.MediaType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -122,6 +123,21 @@ class RoomControllerIntegrationTest extends ControllerIntegrationTestSupport {
 
         assertThat(ownerParticipant.isActive()).isFalse();
         assertThat(joinedParticipant.isActive()).isFalse();
+    }
+
+    @Test
+    void getRoom_returns_room_info_by_room_code() throws Exception {
+        UserJpaEntity owner = saveUser("get-room-owner@test.com", "password123!", "owner", "Owner");
+        RoomJpaEntity room = saveRoom("Room Info", owner);
+
+        mockMvc.perform(get("/api/rooms/{roomCode}", room.getRoomCode())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(owner.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.roomId").value(room.getId()))
+                .andExpect(jsonPath("$.title").value("Room Info"))
+                .andExpect(jsonPath("$.status").value(RoomStatus.RUNNING.name()))
+                .andExpect(jsonPath("$.hostId").value(owner.getId()))
+                .andExpect(jsonPath("$.createdAt").isNotEmpty());
     }
 
     @Test

--- a/src/test/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomControllerIntegrationTest.java
+++ b/src/test/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomControllerIntegrationTest.java
@@ -6,12 +6,14 @@ import com.ssafy.ssafy_project.roomparticipant.adapter.out.persistence.entity.Ro
 import com.ssafy.ssafy_project.roomparticipant.domain.RoomParticipantRole;
 import com.ssafy.ssafy_project.support.ControllerIntegrationTestSupport;
 import com.ssafy.ssafy_project.user.adapter.out.persistence.entity.UserJpaEntity;
+import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -138,6 +140,20 @@ class RoomControllerIntegrationTest extends ControllerIntegrationTestSupport {
                 .andExpect(jsonPath("$.status").value(RoomStatus.RUNNING.name()))
                 .andExpect(jsonPath("$.hostId").value(owner.getId()))
                 .andExpect(jsonPath("$.createdAt").isNotEmpty());
+    }
+
+    @Test
+    void getRoom_throws_exception_when_room_is_ended() {
+        UserJpaEntity owner = saveUser("get-ended-room-owner@test.com", "password123!", "owner", "Owner");
+        RoomJpaEntity room = saveRoom("Ended Room", owner);
+        room.endRoom();
+        roomJpaRepository.save(room);
+
+        assertThatThrownBy(() -> mockMvc.perform(get("/api/rooms/{roomCode}", room.getRoomCode())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(owner.getId()))))
+                .isInstanceOf(ServletException.class)
+                .hasRootCauseInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Request processing failed");
     }
 
     @Test

--- a/src/test/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomParticipationControllerIntegrationTest.java
+++ b/src/test/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomParticipationControllerIntegrationTest.java
@@ -92,7 +92,7 @@ class RoomParticipationControllerIntegrationTest extends ControllerIntegrationTe
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(participant.getId())))
                 .andExpect(status().isOk());
 
-        mockMvc.perform(post("/api/rooms/{roomCode}/leave", room.getRoomCode())
+        mockMvc.perform(post("/api/rooms/{roomId}/leave", room.getId())
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(participant.getId())))
                 .andExpect(status().isOk());
 
@@ -106,7 +106,7 @@ class RoomParticipationControllerIntegrationTest extends ControllerIntegrationTe
 
     @Test
     void leaveRoom_requires_authentication() throws Exception {
-        mockMvc.perform(post("/api/rooms/{roomCode}/leave", "ABCDEFGH"))
+        mockMvc.perform(post("/api/rooms/{roomId}/leave", 1L))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -116,7 +116,7 @@ class RoomParticipationControllerIntegrationTest extends ControllerIntegrationTe
         UserJpaEntity outsider = saveUser("outsider@test.com", "password123!", "outsider", "Outsider");
         RoomJpaEntity room = saveRoom("Non Participant Room", owner);
 
-        assertThatThrownBy(() -> mockMvc.perform(post("/api/rooms/{roomCode}/leave", room.getRoomCode())
+        assertThatThrownBy(() -> mockMvc.perform(post("/api/rooms/{roomId}/leave", room.getId())
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(outsider.getId()))))
                 .isInstanceOf(ServletException.class)
                 .hasRootCauseInstanceOf(RuntimeException.class)
@@ -148,7 +148,7 @@ class RoomParticipationControllerIntegrationTest extends ControllerIntegrationTe
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(participant.getId())))
                 .andExpect(status().isOk());
 
-        mockMvc.perform(post("/api/rooms/{roomCode}/leave", room.getRoomCode())
+        mockMvc.perform(post("/api/rooms/{roomId}/leave", roomId)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(owner.getId())))
                 .andExpect(status().isOk());
 

--- a/src/test/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomParticipationControllerIntegrationTest.java
+++ b/src/test/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomParticipationControllerIntegrationTest.java
@@ -84,6 +84,21 @@ class RoomParticipationControllerIntegrationTest extends ControllerIntegrationTe
     }
 
     @Test
+    void joinRoom_throws_exception_when_room_is_ended() {
+        UserJpaEntity owner = saveUser("ended-join-owner@test.com", "password123!", "owner", "Owner");
+        UserJpaEntity participant = saveUser("ended-join-participant@test.com", "password123!", "participant", "Participant");
+        RoomJpaEntity room = saveRoom("Ended Join Room", owner);
+        room.endRoom();
+        roomJpaRepository.save(room);
+
+        assertThatThrownBy(() -> mockMvc.perform(post("/api/rooms/{roomCode}/join", room.getRoomCode())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(participant.getId()))))
+                .isInstanceOf(ServletException.class)
+                .hasRootCauseInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Request processing failed");
+    }
+
+    @Test
     void leaveRoom_deactivates_active_participant() throws Exception {
         UserJpaEntity owner = saveUser("leave-owner@test.com", "password123!", "owner", "Owner");
         UserJpaEntity participant = saveUser("leave-participant@test.com", "password123!", "participant", "Participant");

--- a/src/test/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomParticipationControllerIntegrationTest.java
+++ b/src/test/java/com/ssafy/ssafy_project/room/adapter/in/web/RoomParticipationControllerIntegrationTest.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpHeaders;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -164,5 +165,69 @@ class RoomParticipationControllerIntegrationTest extends ControllerIntegrationTe
         assertThat(endedRoom.getEndedTime()).isNotNull();
         assertThat(ownerParticipant.isActive()).isFalse();
         assertThat(joinedParticipant.isActive()).isFalse();
+    }
+
+    @Test
+    void getParticipants_returns_active_participants_for_active_participant() throws Exception {
+        UserJpaEntity owner = saveUser("participants-owner@test.com", "password123!", "owner", "Owner");
+        UserJpaEntity participant = saveUser("participants-joiner@test.com", "password123!", "joiner", "Joiner");
+        UserJpaEntity leftParticipant = saveUser("participants-left@test.com", "password123!", "left", "Left");
+        String responseBody = mockMvc.perform(post("/api/rooms")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(owner.getId()))
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title": "Participants Room"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        Long roomId = objectMapper.readTree(responseBody).get("roomId").asLong();
+        RoomJpaEntity room = roomJpaRepository.findById(roomId).orElseThrow();
+
+        mockMvc.perform(post("/api/rooms/{roomCode}/join", room.getRoomCode())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(participant.getId())))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/rooms/{roomCode}/join", room.getRoomCode())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(leftParticipant.getId())))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/rooms/{roomId}/leave", room.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(leftParticipant.getId())))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/rooms/{roomId}/participants", room.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(participant.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.users.length()").value(2))
+                .andExpect(jsonPath("$.users[0].userId").isNumber())
+                .andExpect(jsonPath("$.users[*].userId").value(org.hamcrest.Matchers.containsInAnyOrder(
+                        owner.getId().intValue(),
+                        participant.getId().intValue()
+                )))
+                .andExpect(jsonPath("$.users[?(@.userId == %s)]", leftParticipant.getId()).doesNotExist());
+    }
+
+    @Test
+    void getParticipants_requires_authentication() throws Exception {
+        mockMvc.perform(get("/api/rooms/{roomId}/participants", 1L))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getParticipants_fails_for_non_active_participant() throws Exception {
+        UserJpaEntity owner = saveUser("participants-owner2@test.com", "password123!", "owner2", "Owner2");
+        UserJpaEntity outsider = saveUser("participants-outsider@test.com", "password123!", "outsider", "Outsider");
+        RoomJpaEntity room = saveRoom("Participants Guard Room", owner);
+
+        assertThatThrownBy(() -> mockMvc.perform(get("/api/rooms/{roomId}/participants", room.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(outsider.getId()))))
+                .isInstanceOf(ServletException.class)
+                .hasRootCauseInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Request processing failed");
     }
 }


### PR DESCRIPTION
# Room 정보 조회 및 RoomParticipant 조회 PR 정리

## 개요

`Room` 도메인에 방 정보 조회 기능을 추가했고, `RoomParticipant` 도메인에는 현재 방 참가자 목록 조회 기능을 추가했습니다.  
추가로 닫힌 방에 대해 조회하거나 참가하려는 요청은 예외가 발생하도록 처리했습니다.

- 방 정보 조회: 사용자가 `roomCode`로 방 정보를 조회
- 방 참가자 조회: 현재 방에 active 상태로 참가 중인 사용자만 참가자 목록 조회 가능
- 닫힌 방 조회 제한: `ENDED` 상태의 방은 정보 조회 시 예외 발생
- 닫힌 방 참가 제한: `ENDED` 상태의 방은 join 시 예외 발생
- 방 퇴장 리소스 정리: 방 퇴장 API는 `roomCode` 대신 `roomId`를 사용하도록 정리

## 주요 변경 사항

### 1. Room 정보 조회 유스케이스 추가

헥사고날 아키텍처 흐름에 맞게 방 정보 조회용 입력 포트와 애플리케이션 모델을 추가했습니다.

- In Port
  - `GetRoomPortIn`

- Application Model
  - `GetRoomCommand`
  - `GetRoomResult`

컨트롤러는 `roomCode`를 `GetRoomCommand`로 변환해서 서비스에 전달하고, 서비스 결과를 `GetRoomResponse`로 변환해서 응답합니다.

### 2. RoomParticipant 참가자 조회 유스케이스 추가

방 참가자 조회 기능을 위해 입력 포트, 출력 포트, 응답 모델을 추가했습니다.

- In Port
  - `GetParticipantsPortIn`

- Out Port
  - `LoadParticipantsPortOut`

- Application Model
  - `GetParticipantsCommand`
  - `GetParticipantsResult`

- Response DTO
  - `ParticipantResponse`
  - `ParticipantsResponse`

### 3. Room 정보 조회 로직

- 요청값: `roomCode`
- `roomCode`로 방을 조회
- 방이 `ENDED` 상태이면 예외 발생
- 조회 성공 시 아래 정보를 반환
  - `roomId`
  - `title`
  - `status`
  - `hostId`
  - `createdAt`

즉, 클라이언트는 방 참가 전에 `roomCode`만으로 방의 기본 정보를 확인할 수 있습니다.

### 4. RoomParticipant 참가자 조회 로직

- 요청값: `roomId`, `loginUserId`
- 요청자가 해당 방에 active 상태로 참가 중인지 먼저 확인
- 참가 중인 경우에만 같은 방의 active 참가자 목록을 조회
- 비참가자이거나 이미 퇴장한 사용자는 예외 발생

조회 대상은 `isActive = true`인 참가자만 포함합니다.

### 5. 닫힌 방 요청 예외 처리

방이 이미 종료된 경우에는 조회/참가 모두 막히도록 처리했습니다.

- `RoomService.getRoom()`
  - `roomCode`로 조회한 방이 `ENDED`면 예외 발생

- `RoomParticipantService.saveRoomParticipant()`
  - `roomCode`로 조회한 방이 `ENDED`면 예외 발생

현재 예외는 공통 예외 타입으로 분리하지 않고 `RuntimeException` 기반으로 처리했습니다.

### 6. 방 퇴장 API 리소스 식별자 정리

기존에는 방 퇴장 시 `roomCode` 기반으로 처리되던 흐름이 있었는데, 현재는 방에 입장해 `roomId`를 알고 있는 상태를 기준으로 `roomId`를 사용하도록 정리했습니다.

- 방 참가: `roomCode` 사용
- 방 정보 조회: `roomCode` 사용
- 방 나가기: `roomId` 사용
- 방 참가자 조회: `roomId` 사용

## 계층별 흐름

### 방 정보 조회

`GET /api/rooms/{roomCode}`
-> `RoomController`
-> `GetRoomCommand`
-> `GetRoomPortIn`
-> `RoomService`
-> `LoadRoomPortOut.loadByRoomCode(...)`
-> 종료 여부 검증
-> `GetRoomResult`
-> `GetRoomResponse`

### 방 참가자 조회

`GET /api/rooms/{roomId}/participants`
-> `RoomParticipationController`
-> `GetParticipantsCommand`
-> `GetParticipantsPortIn`
-> `RoomParticipantService`
-> `FindRoomParticipantPortOut.findByRoom_IdAndUser_IdAndIsActiveTrue(...)`
-> `LoadParticipantsPortOut.loadAllByRoomIdAndIsActiveTrue(...)`
-> `ParticipantsResponse`

### 닫힌 방 참가 제한

`POST /api/rooms/{roomCode}/join`
-> `RoomParticipationController`
-> `JoinRoomCommand`
-> `SaveRoomParticipantPortIn`
-> `RoomParticipantService`
-> `LoadRoomPortOut.loadByRoomCode(...)`
-> 종료 여부 검증
-> 예외 발생 또는 기존 참가/신규 참가 처리

## API 요약

### 방 정보 조회

- `GET /api/rooms/{roomCode}`

Response

```json
{
  "roomId": 1,
  "title": "테스트 방",
  "status": "RUNNING",
  "hostId": 10,
  "createdAt": "2026-03-31T21:00:00"
}
```

### 방 참가자 조회

- `GET /api/rooms/{roomId}/participants`

Response

```json
{
  "users": [
    {
      "userId": 10,
      "email": "owner@test.com",
      "nickname": "owner",
      "name": "Owner"
    },
    {
      "userId": 11,
      "email": "participant@test.com",
      "nickname": "participant",
      "name": "Participant"
    }
  ]
}
```

## Room / RoomParticipant 연동 사항

### 1. 방 정보 조회와 참가 흐름 연결

- 사용자는 `roomCode`로 방 정보를 조회할 수 있음
- 같은 `roomCode`를 사용해 방 참가 요청을 보낼 수 있음
- 두 흐름 모두 닫힌 방인지 동일하게 검증함

### 2. 참가자 조회 접근 제어

- 단순히 `roomId`를 안다고 해서 참가자 목록을 볼 수는 없음
- active 참가자인 경우에만 참가자 목록 조회 가능

### 3. 종료된 방 정책 일관화

- 종료된 방은 조회 불가
- 종료된 방은 join 불가

즉, 종료된 방에 대해서는 더 이상 새 진입 흐름이 동작하지 않도록 막았습니다.

## 설계 관점

### 헥사고날 아키텍처

- web adapter의 Request/Response DTO와 application 계층의 Command/Result를 분리했습니다.
- application 계층은 web DTO나 JPA Entity를 직접 의존하지 않도록 구성했습니다.
- 서비스는 port를 통해 외부 자원에 접근합니다.
- 조회 기능도 기존 생성/참가 흐름과 동일한 port 기반 구조로 맞췄습니다.

### SOLID

- SRP
  - `RoomController`: 방 정보 조회 요청/응답 변환 담당
  - `RoomParticipationController`: 참가/퇴장/참가자 조회 요청/응답 변환 담당
  - `RoomService`: 방 정보 조회 정책 담당
  - `RoomParticipantService`: 방 참가자 조회 정책 및 참가 검증 담당

- DIP
  - 서비스는 구현체가 아니라 port interface에 의존합니다.

- ISP
  - 방 정보 조회와 참가자 조회를 각각 별도의 in port로 분리했습니다.
  - 참가자 조회용 목록 조회 책임을 `LoadParticipantsPortOut`으로 분리했습니다.

## 검증

아래 통합 테스트를 추가 또는 수정하고 통과를 확인했습니다.

- `RoomControllerIntegrationTest`
  - 방 정보 조회 성공
  - 닫힌 방 정보 조회 시 예외 발생

- `RoomParticipationControllerIntegrationTest`
  - active 참가자 기준 참가자 목록 조회 성공
  - 비참가자 참가자 목록 조회 시 예외 발생
  - 닫힌 방 join 시 예외 발생

실행 확인

- `./mvnw -q -Dtest=RoomControllerIntegrationTest,RoomParticipationControllerIntegrationTest test` 통과

## 참고

- 현재 예외 처리는 `RuntimeException` 기반으로 되어 있어, 이후에는 공통 예외 타입과 예외 응답 포맷으로 정리할 수 있습니다.
- 현재 닫힌 방 요청 테스트는 상태코드나 메시지 고정보다 "예외가 발생하는가"에 초점을 맞춰 작성했습니다.
- 참가자 조회는 active 참가자만 대상으로 하기 때문에, 퇴장한 사용자는 목록에서 제외됩니다.
## base branch를 develop으로 설정 부탁드립니다..