### PR TITLE
feature : ChatMessageJpaEntity 및 ChatMessageJpaRepository 생성

### DIFF
--- a/src/main/java/com/ssafy/ssafy_project/chat/adapter/out/persistence/entity/ChatMessageJpaEntity.java
+++ b/src/main/java/com/ssafy/ssafy_project/chat/adapter/out/persistence/entity/ChatMessageJpaEntity.java
@@ -1,0 +1,45 @@
+package com.ssafy.ssafy_project.chat.adapter.out.persistence.entity;
+
+import com.ssafy.ssafy_project.room.adapter.out.persistence.entity.RoomJpaEntity;
+import com.ssafy.ssafy_project.user.adapter.out.persistence.entity.UserJpaEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Table(name = "chat_messages")
+public class ChatMessageJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private RoomJpaEntity roomJpaEntity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private UserJpaEntity userJpaEntity;
+
+    @Column(name = "sender_nickname", nullable = false)
+    private String senderNickname;
+
+
+    @Column(name = "message", nullable = false)
+    private String message;
+
+    @CreationTimestamp
+    @Column(name="created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+}

--- a/src/main/java/com/ssafy/ssafy_project/chat/adapter/out/persistence/repository/ChatMessageJpaRepository.java
+++ b/src/main/java/com/ssafy/ssafy_project/chat/adapter/out/persistence/repository/ChatMessageJpaRepository.java
@@ -1,0 +1,9 @@
+package com.ssafy.ssafy_project.chat.adapter.out.persistence.repository;
+
+import com.ssafy.ssafy_project.chat.adapter.out.persistence.entity.ChatMessageJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatMessageJpaRepository extends JpaRepository<ChatMessageJpaEntity, Long> {
+}


### PR DESCRIPTION
# ChatMessage 엔티티 및 Repository 기본 세팅

## 개요

채팅 기능 구현을 위한 첫 단계로 `ChatMessage` persistence 기본 구조를 추가했습니다.

이번 PR에서는 채팅 메시지를 저장할 수 있는 JPA 엔티티와 기본 repository를 생성했습니다.

- 채팅 메시지 엔티티 추가
- 방 / 발신자 사용자 연관 관계 매핑
- 발신자 닉네임 스냅샷 필드 추가
- 생성 시간 / 소프트 삭제 필드 추가
- 기본 `JpaRepository` 생성

즉, 이후 채팅 저장/조회 기능을 붙일 수 있는 최소 persistence 기반을 마련하는 작업입니다.

## 주요 변경 사항

### 1. ChatMessage JPA 엔티티 추가

추가 파일:

- `src/main/java/com/ssafy/ssafy_project/chat/adapter/out/persistence/entity/ChatMessageJpaEntity.java`

엔티티에 포함된 필드는 다음과 같습니다.

- `id`
- `roomJpaEntity`
- `userJpaEntity`
- `senderNickname`
- `message`
- `createdAt`
- `isDeleted`

### 2. 방 / 사용자 연관 관계 매핑

채팅 메시지는 특정 방에 속하고, 특정 사용자가 보낸 메시지이므로 아래 연관 관계를 설정했습니다.

- `@ManyToOne(fetch = FetchType.LAZY)` -> `RoomJpaEntity`
- `@ManyToOne(fetch = FetchType.LAZY)` -> `UserJpaEntity`

즉 메시지 하나는

- 하나의 방에 속하고
- 하나의 발신자를 가집니다.

### 3. 발신자 닉네임 저장

메시지에는 `senderNickname` 필드를 별도로 두었습니다.

`sender_id`만 저장해도 사용자 조회 자체는 가능하지만, 채팅 메시지 목록을 읽을 때마다 사용자 테이블을 조인해야 합니다.

이번 구조에서는 메시지에 닉네임을 함께 저장해서 다음 장점을 가져갑니다.

- 메시지 조회 시 사용자 조인 의존도를 줄일 수 있음
- 채팅 목록 응답을 더 단순하게 구성할 수 있음
- 메시지 테이블만으로도 발신자 표시값을 바로 사용할 수 있음

즉 `senderNickname`은 닉네임 변경 이력 보존이 핵심 목적이라기보다, 이후 메시지 조회를 더 편하게 하기 위한 필드입니다.

### 4. 생성 시간 / 소프트 삭제 필드 추가

채팅 메시지 관리에 필요한 기본 메타데이터도 함께 반영했습니다.

- `createdAt`
  - `@CreationTimestamp` 기반 생성 시각

- `isDeleted`
  - 기본값 `false`
  - 이후 메시지 삭제 시 소프트 삭제로 확장 가능

즉, 지금 단계에서는 삭제 API를 구현하지 않더라도, 엔티티 차원에서 soft delete 구조를 미리 준비한 상태입니다.

### 5. ChatMessage Repository 추가

추가 파일:

- `src/main/java/com/ssafy/ssafy_project/chat/adapter/out/persistence/repository/ChatMessageJpaRepository.java`

현재는 기본 `JpaRepository<ChatMessageJpaEntity, Long>`만 선언했습니다.

이후 채팅 기능 구현 단계에서 아래와 같은 메서드를 추가할 수 있습니다.

- 방별 메시지 조회
- 생성 시간 기준 정렬 조회
- 삭제되지 않은 메시지 조회

## 설계 관점

### 1. 채팅 메시지 조회 최적화 기반 마련

메시지에는 `sender_id`뿐 아니라 `senderNickname`도 함께 저장합니다.

이 구조는 다음 이유로 적절합니다.

- 채팅 메시지 조회 시 사용자 조인을 줄일 수 있음
- 방별 메시지 목록 응답을 단순하게 만들 수 있음
- 조회 전용 응답 모델 구성 시 필요한 데이터를 메시지 row 안에서 바로 꺼낼 수 있음

즉 채팅 기능 특성상 자주 발생하는 메시지 목록 조회를 더 단순하게 만들기 위한 구조입니다.

### 2. soft delete 확장 가능성 확보

메시지를 즉시 물리 삭제하지 않고 `isDeleted` 플래그를 두어, 이후 아래 정책으로 확장할 수 있도록 했습니다.

- 삭제된 메시지 필터링
- 삭제된 메시지 마스킹 처리
- 관리자 조회 기능

### 3. 최소 범위 우선 적용

이번 PR은 채팅 기능 전체 구현이 아니라 persistence 시작점만 다룹니다.

즉 아래는 아직 이번 범위에 포함되지 않습니다.

- 채팅 저장 유스케이스
- 채팅 조회 API
- WebSocket/STOMP 송수신
- 메시지 삭제 API

## 계층별 위치

### Persistence Entity

`chat/adapter/out/persistence/entity/ChatMessageJpaEntity`

### Repository

`chat/adapter/out/persistence/repository/ChatMessageJpaRepository`

## 검증

현재 PR에서는 엔티티와 repository 기본 세팅이 목적이므로, 이후 저장/조회 유스케이스 구현 시 통합 테스트를 추가하는 방향으로 이어집니다.

## 참고

- 현재 엔티티는 채팅 메시지 persistence 기본 구조를 마련한 단계입니다.
- 이후 구현에서는 컬럼명 명시, 조회 메서드 추가, 채팅 도메인 모델 분리 여부 등을 검토할 수 있습니다.
