### PR TITLE
test :  USER API 통합 테스트

### DIFF
--- a/src/test/java/com/ssafy/ssafy_project/support/ControllerIntegrationTestSupport.java
+++ b/src/test/java/com/ssafy/ssafy_project/support/ControllerIntegrationTestSupport.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -106,6 +107,7 @@ public abstract class ControllerIntegrationTestSupport {
 
         @Bean
         @ServiceConnection
+        @ConditionalOnProperty(name = "test.use-testcontainers", havingValue = "true", matchIfMissing = true)
         PostgreSQLContainer<?> postgresContainer() {
             return new PostgreSQLContainer<>("postgres:16-alpine");
         }

--- a/src/test/java/com/ssafy/ssafy_project/support/TestInfraConfig.java
+++ b/src/test/java/com/ssafy/ssafy_project/support/TestInfraConfig.java
@@ -2,6 +2,7 @@ package com.ssafy.ssafy_project.support;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ssafy.ssafy_project.global.application.port.out.RefreshTokenPortOut;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
@@ -17,6 +18,7 @@ public class TestInfraConfig {
 
     @Bean
     @ServiceConnection
+    @ConditionalOnProperty(name = "test.use-testcontainers", havingValue = "true", matchIfMissing = true)
     PostgreSQLContainer<?> postgresContainer() {
         return new PostgreSQLContainer<>("postgres:16-alpine");
     }

--- a/src/test/java/com/ssafy/ssafy_project/user/adapter/in/web/UserControllerIntegrationTest.java
+++ b/src/test/java/com/ssafy/ssafy_project/user/adapter/in/web/UserControllerIntegrationTest.java
@@ -1,0 +1,190 @@
+package com.ssafy.ssafy_project.user.adapter.in.web;
+
+import com.ssafy.ssafy_project.room.adapter.out.persistence.entity.RoomJpaEntity;
+import com.ssafy.ssafy_project.room.domain.RoomStatus;
+import com.ssafy.ssafy_project.roomparticipant.adapter.out.persistence.entity.RoomParticipantJpaEntity;
+import com.ssafy.ssafy_project.support.ControllerIntegrationTestSupport;
+import com.ssafy.ssafy_project.user.adapter.out.persistence.entity.UserJpaEntity;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class UserControllerIntegrationTest extends ControllerIntegrationTestSupport {
+
+    @BeforeEach
+    void setUp() {
+        clearPersistence();
+    }
+
+    @Test
+    void getMyInfo_returns_authenticated_user_info() throws Exception {
+        UserJpaEntity user = saveUser("me@test.com", "password123!", "me-user", "Me User");
+
+        mockMvc.perform(get("/api/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(user.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(user.getId()))
+                .andExpect(jsonPath("$.email").value("me@test.com"))
+                .andExpect(jsonPath("$.nickname").value("me-user"))
+                .andExpect(jsonPath("$.name").value("Me User"))
+                .andExpect(jsonPath("$.profileImageUrl").isEmpty());
+    }
+
+    @Test
+    void getMyInfo_requires_authentication() throws Exception {
+        mockMvc.perform(get("/api/users/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void updateUserNickname_updates_persisted_nickname() throws Exception {
+        UserJpaEntity user = saveUser("nickname@test.com", "password123!", "before-name", "Nickname User");
+
+        mockMvc.perform(patch("/api/users/me/nickname")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(user.getId()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "nickname": "after-name"
+                                }
+                                """))
+                .andExpect(status().isNoContent());
+
+        UserJpaEntity updatedUser = userJpaRepository.findById(user.getId()).orElseThrow();
+        assertThat(updatedUser.getNickname()).isEqualTo("after-name");
+    }
+
+    @Test
+    void updateUserNickname_rejects_blank_nickname() throws Exception {
+        UserJpaEntity user = saveUser("invalid-nickname@test.com", "password123!", "valid-name", "Valid User");
+
+        mockMvc.perform(patch("/api/users/me/nickname")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(user.getId()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "nickname": ""
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void updateUserNickname_requires_authentication() throws Exception {
+        mockMvc.perform(patch("/api/users/me/nickname")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "nickname": "after-name"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void withdrawUser_soft_deletes_user_and_cleans_related_state() throws Exception {
+        UserJpaEntity withdrawingUser = saveUser("withdraw@test.com", "password123!", "withdraw-user", "Withdraw User");
+        UserJpaEntity guestOwner = saveUser("guest-owner@test.com", "password123!", "guest-owner", "Guest Owner");
+        UserJpaEntity otherParticipant = saveUser("other-participant@test.com", "password123!", "other-participant", "Other Participant");
+
+        String hostRoomResponse = mockMvc.perform(post("/api/rooms")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(withdrawingUser.getId()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title": "Hosted Room"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        Long hostedRoomId = objectMapper.readTree(hostRoomResponse).get("roomId").asLong();
+        RoomJpaEntity hostedRoom = roomJpaRepository.findById(hostedRoomId).orElseThrow();
+
+        mockMvc.perform(post("/api/rooms/{roomCode}/join", hostedRoom.getRoomCode())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(otherParticipant.getId())))
+                .andExpect(status().isOk());
+
+        RoomJpaEntity joinedRoom = saveRoom("Joined Room", guestOwner);
+        mockMvc.perform(post("/api/rooms/{roomCode}/join", joinedRoom.getRoomCode())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(withdrawingUser.getId())))
+                .andExpect(status().isOk());
+
+        String setCookieHeader = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "withdraw@test.com",
+                                  "password": "password123!"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getHeader(HttpHeaders.SET_COOKIE);
+
+        String refreshToken = extractCookieValue(setCookieHeader, "refreshToken");
+        assertThat(refreshTokenPortOut.find(withdrawingUser.getId())).contains(refreshToken);
+
+        mockMvc.perform(delete("/api/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(withdrawingUser.getId()))
+                        .cookie(new Cookie("refreshToken", refreshToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "password": "password123!"
+                                }
+                                """))
+                .andExpect(status().isNoContent())
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("refreshToken=")))
+                .andExpect(cookie().maxAge("refreshToken", 0));
+
+        UserJpaEntity deletedUser = userJpaRepository.findById(withdrawingUser.getId()).orElseThrow();
+        RoomJpaEntity endedHostedRoom = roomJpaRepository.findById(hostedRoomId).orElseThrow();
+        RoomParticipantJpaEntity joinedRoomParticipant = roomParticipantJpaRepository
+                .findByRoomJpaEntity_IdAndUserJpaEntity_Id(joinedRoom.getId(), withdrawingUser.getId())
+                .orElseThrow();
+        RoomParticipantJpaEntity hostedRoomOwnerParticipant = roomParticipantJpaRepository
+                .findByRoomJpaEntity_IdAndUserJpaEntity_Id(hostedRoomId, withdrawingUser.getId())
+                .orElseThrow();
+        RoomParticipantJpaEntity hostedRoomOtherParticipant = roomParticipantJpaRepository
+                .findByRoomJpaEntity_IdAndUserJpaEntity_Id(hostedRoomId, otherParticipant.getId())
+                .orElseThrow();
+
+        assertThat(deletedUser.isDeleted()).isTrue();
+        assertThat(endedHostedRoom.getStatus()).isEqualTo(RoomStatus.ENDED);
+        assertThat(endedHostedRoom.getEndedTime()).isNotNull();
+        assertThat(joinedRoomParticipant.isActive()).isFalse();
+        assertThat(joinedRoomParticipant.getDurationTime()).isGreaterThanOrEqualTo(0L);
+        assertThat(hostedRoomOwnerParticipant.isActive()).isFalse();
+        assertThat(hostedRoomOtherParticipant.isActive()).isFalse();
+        assertThat(refreshTokenPortOut.find(withdrawingUser.getId())).isEmpty();
+    }
+
+    @Test
+    void withdrawUser_requires_authentication() throws Exception {
+        mockMvc.perform(delete("/api/users/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "password": "password123!"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
  ## 제목
  - USER API 통합 테스트 추가

  ## 작업 내용
  - `UserControllerIntegrationTest` 추가
  - 사용자 조회/닉네임 수정/회원 탈퇴 API에 대한 통합 테스트 작성
  - 테스트 환경에서 `RefreshTokenPortOut`을 In-Memory 구현으로 대체
  - Testcontainers 기반 DB와 로컬 DB 기반 테스트를 선택적으로 사용할 수 있도록 조건 추가

  ## 상세 변경 사항
  - `GET /api/users/me`
    - 인증된 사용자의 내 정보 조회 성공 케이스 검증
    - 미인증 요청 시 `401 Unauthorized` 반환 검증

  - `PATCH /api/users/me/nickname`
    - 닉네임 변경 성공 및 실제 DB 반영 여부 검증
    - 빈 문자열 닉네임 요청 시 `400 Bad Request` 검증
    - 미인증 요청 시 `401 Unauthorized` 반환 검증

  - `DELETE /api/users/me`
    - 회원 탈퇴 성공 시 소프트 딜리트 처리 검증
    - 사용자가 방장인 방은 종료 처리되는지 검증
    - 참여 중인 방의 참가 상태가 비활성화되는지 검증
    - 리프레시 토큰 쿠키 삭제 및 저장소 정리 검증
    - 미인증 요청 시 `401 Unauthorized` 반환 검증

  ## 테스트 환경
  - 기본값은 Testcontainers(PostgreSQL) 기반으로 동작
  - 필요 시 로컬 DB 기반으로도 실행 가능하도록 `test.use-testcontainers` 조건 추가

  예시:
  ```bash
  mvnw.cmd -Dtest.use-testcontainers=false -Dtest=UserControllerIntegrationTest test

  ## 기대 효과

  - USER API의 주요 시나리오를 HTTP 레벨에서 회귀 검증 가능
  - 회원 탈퇴 시 사용자/방/참가자/토큰 정리까지 함께 검증하여 사이드 이펙트 누락 방지
  - 팀원별 환경에 따라 컨테이너 DB/로컬 DB를 선택해 테스트 가능