### PR TITLE
 채팅방 나가기 시 백엔드에서 WebSocket 연결 종료 처리

### DIFF
--- a/src/main/java/com/ssafy/ssafy_project/global/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/ssafy_project/global/infrastructure/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
 
     private static final String[] whiteList = {
             "/api/auth/**",
+            "/ws",
             "/ws/**",
             "/ws-stomp/**"
     };

--- a/src/main/java/com/ssafy/ssafy_project/global/infrastructure/config/WebSocketConfig.java
+++ b/src/main/java/com/ssafy/ssafy_project/global/infrastructure/config/WebSocketConfig.java
@@ -1,21 +1,30 @@
 package com.ssafy.ssafy_project.global.infrastructure.config;
 
 import com.ssafy.ssafy_project.global.infrastructure.websocket.WebSocketAuthChannelInterceptor;
+import com.ssafy.ssafy_project.global.infrastructure.websocket.WebSocketSessionRegistry;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
+import org.springframework.web.socket.handler.WebSocketHandlerDecorator;
 
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final WebSocketAuthChannelInterceptor webSocketAuthChannelInterceptor;
+    private final WebSocketSessionRegistry webSocketSessionRegistry;
 
-    public WebSocketConfig(WebSocketAuthChannelInterceptor webSocketAuthChannelInterceptor) {
+    public WebSocketConfig(
+            WebSocketAuthChannelInterceptor webSocketAuthChannelInterceptor,
+            WebSocketSessionRegistry webSocketSessionRegistry) {
         this.webSocketAuthChannelInterceptor = webSocketAuthChannelInterceptor;
+        this.webSocketSessionRegistry = webSocketSessionRegistry;
     }
 
     @Override
@@ -34,4 +43,23 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(webSocketAuthChannelInterceptor);
     }
+
+    @Override
+    public void configureWebSocketTransport(WebSocketTransportRegistration registration) {
+        registration.addDecoratorFactory(handler -> new WebSocketHandlerDecorator(handler) {
+            @Override
+            public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+                webSocketSessionRegistry.registerSession(session);
+                super.afterConnectionEstablished(session);
+            }
+
+            @Override
+            public void afterConnectionClosed(WebSocketSession session, CloseStatus closeStatus) throws Exception {
+                webSocketSessionRegistry.unregisterSession(session.getId());
+                super.afterConnectionClosed(session, closeStatus);
+            }
+        });
+    }
+
+
 }

--- a/src/main/java/com/ssafy/ssafy_project/global/infrastructure/websocket/WebSocketAuthChannelInterceptor.java
+++ b/src/main/java/com/ssafy/ssafy_project/global/infrastructure/websocket/WebSocketAuthChannelInterceptor.java
@@ -27,6 +27,7 @@ public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
 
     private final JwtPortOut jwtPortOut;
     private final FindRoomParticipantPortOut findRoomParticipantPortOut;
+    private final WebSocketSessionRegistry webSocketSessionRegistry;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -43,6 +44,10 @@ public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
 
         if (StompCommand.SUBSCRIBE.equals(command)) {
             authorizeSubscribe(accessor);
+        }
+
+        if (StompCommand.DISCONNECT.equals(command)) {
+            unregister(accessor);
         }
 
         return message;
@@ -66,6 +71,11 @@ public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
         Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
         if (sessionAttributes != null) {
             sessionAttributes.put(USER_ID_SESSION_KEY, userId);
+        }
+
+        String sessionId = accessor.getSessionId();
+        if (sessionId != null) {
+            webSocketSessionRegistry.bindUser(sessionId, userId);
         }
     }
 
@@ -115,6 +125,13 @@ public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
             return null;
         }
         return values.getFirst();
+    }
+
+    private void unregister(StompHeaderAccessor accessor) {
+        String sessionId = accessor.getSessionId();
+        if (sessionId != null) {
+            webSocketSessionRegistry.unregisterSession(sessionId);
+        }
     }
 
     private Long extractRoomId(String destination) {

--- a/src/main/java/com/ssafy/ssafy_project/global/infrastructure/websocket/WebSocketSessionRegistry.java
+++ b/src/main/java/com/ssafy/ssafy_project/global/infrastructure/websocket/WebSocketSessionRegistry.java
@@ -1,0 +1,82 @@
+package com.ssafy.ssafy_project.global.infrastructure.websocket;
+
+import com.ssafy.ssafy_project.roomparticipant.application.port.out.CloseUserWebSocketSessionsPortOut;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+public class WebSocketSessionRegistry implements CloseUserWebSocketSessionsPortOut {
+
+    private final ConcurrentHashMap<String, WebSocketSession> sessions = new ConcurrentHashMap<>();
+
+    private final ConcurrentHashMap<String, Long> sessionUsers = new ConcurrentHashMap<>();
+
+    private final ConcurrentHashMap<Long, Set<String>> userSessions = new ConcurrentHashMap<>();
+
+    public void registerSession(WebSocketSession session){
+        sessions.put(session.getId(), session);
+        log.debug("WebSocket session registered. sessionId={}", session.getId());
+    }
+
+    public void bindUser(String sessionId, Long userId){
+        sessionUsers.put(sessionId, userId);
+        userSessions
+                .computeIfAbsent(userId, key -> ConcurrentHashMap.newKeySet())
+                .add(sessionId);
+
+        log.debug("WebSocket session bound. sessionId={}, userId={}", sessionId, userId);
+    }
+
+    public void unregisterSession(String sessionId){
+        sessions.remove(sessionId);
+
+        Long userId = sessionUsers.remove(sessionId);
+        if(userId != null) {
+            Set<String> sessionIds = userSessions.get(userId);
+            if (sessionIds != null) {
+                sessionIds.remove(sessionId);
+
+                if (sessionIds.isEmpty()) {
+                    userSessions.remove(userId);
+                }
+            }
+        }
+
+        log.debug("WebSocket session unregistered. sessionId={}, userId={}", sessionId, userId);
+    }
+
+    @Override
+    public void closeByUserId(Long userId) {
+        Set<String> sessionIds = userSessions.get(userId);
+
+        if (sessionIds == null || sessionIds.isEmpty()) {
+            log.debug("No WebSocket sessions to close. userId={}", userId);
+            return;
+        }
+
+        for (String sessionId : Set.copyOf(sessionIds)) {
+            WebSocketSession session = sessions.get(sessionId);
+
+            if (session == null || !session.isOpen()) {
+                unregisterSession(sessionId);
+                continue;
+            }
+
+            try {
+                session.close(new CloseStatus(4000, "ROOM_LEFT"));
+                log.info("WebSocket session closed by room leave. userId={}, sessionId={}", userId, sessionId);
+            } catch (IOException e) {
+                log.warn("Failed to close WebSocket session. userId={}, sessionId={}", userId, sessionId, e);
+            } finally {
+                unregisterSession(sessionId);
+            }
+        }
+    }
+}

--- a/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/port/out/CloseUserWebSocketSessionsPortOut.java
+++ b/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/port/out/CloseUserWebSocketSessionsPortOut.java
@@ -1,0 +1,5 @@
+package com.ssafy.ssafy_project.roomparticipant.application.port.out;
+
+public interface CloseUserWebSocketSessionsPortOut {
+    void closeByUserId(Long userId);
+}

--- a/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/service/RoomParticipantService.java
+++ b/src/main/java/com/ssafy/ssafy_project/roomparticipant/application/service/RoomParticipantService.java
@@ -6,6 +6,7 @@ import com.ssafy.ssafy_project.room.domain.Room;
 import com.ssafy.ssafy_project.room.domain.RoomStatus;
 import com.ssafy.ssafy_project.roomparticipant.application.port.in.GetParticipantsResult;
 import com.ssafy.ssafy_project.roomparticipant.application.port.in.*;
+import com.ssafy.ssafy_project.roomparticipant.application.port.out.CloseUserWebSocketSessionsPortOut;
 import com.ssafy.ssafy_project.roomparticipant.application.port.out.FindRoomParticipantPortOut;
 import com.ssafy.ssafy_project.roomparticipant.application.port.out.LoadParticipantsPortOut;
 import com.ssafy.ssafy_project.roomparticipant.application.port.out.SaveRoomParticipantPortOut;
@@ -16,6 +17,8 @@ import com.ssafy.ssafy_project.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,6 +34,7 @@ public class RoomParticipantService implements SaveRoomParticipantPortIn, LeaveR
     private final FindRoomParticipantPortOut findRoomParticipantPortOut;
     private final RoomTerminationProcessor roomTerminationProcessor;
     private final LoadParticipantsPortOut loadParticipantsPortOut;
+    private final CloseUserWebSocketSessionsPortOut closeUserWebSocketSessionsPortOut;
 
     @Transactional
     @Override
@@ -80,10 +84,12 @@ public class RoomParticipantService implements SaveRoomParticipantPortIn, LeaveR
             RoomParticipant roomParticipant = found.get();
             if(roomParticipant.getUser().getId().equals(room.getHostId())){
                 roomTerminationProcessor.terminate(room);
+                closeWebSocketAfterCommit(userId);
                 return;
             }
             roomParticipant.leave();
             saveRoomParticipantPortOut.saveRoomParticipant(roomParticipant);
+            closeWebSocketAfterCommit(userId);
         }
 
         if(found.isEmpty()){
@@ -113,5 +119,19 @@ public class RoomParticipantService implements SaveRoomParticipantPortIn, LeaveR
         }
 
         return getParticipantsResults;
+    }
+
+    private void closeWebSocketAfterCommit(Long userId) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    closeUserWebSocketSessionsPortOut.closeByUserId(userId);
+                }
+            });
+            return;
+        }
+
+        closeUserWebSocketSessionsPortOut.closeByUserId(userId);
     }
 }

--- a/src/main/resources/static/ws-test/index.html
+++ b/src/main/resources/static/ws-test/index.html
@@ -244,7 +244,7 @@
     const statusDot = document.getElementById("statusDot");
     const statusText = document.getElementById("statusText");
 
-    const defaultWsUrl = `${location.protocol === "https:" ? "wss" : "ws"}://${location.host}/ws`;
+    const defaultWsUrl = `ws://localhost:8081/ws`;
     const defaultDeleteBaseUrl = `${location.protocol}//${location.host}`;
     wsUrlInput.value = defaultWsUrl;
     deleteBaseUrlInput.value = defaultDeleteBaseUrl;

--- a/src/test/java/com/ssafy/ssafy_project/chat/adapter/in/web/ChatMessageControllerIntegrationTest.java
+++ b/src/test/java/com/ssafy/ssafy_project/chat/adapter/in/web/ChatMessageControllerIntegrationTest.java
@@ -8,13 +8,13 @@ import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 class ChatMessageControllerIntegrationTest extends ControllerIntegrationTestSupport {
 
@@ -24,81 +24,49 @@ class ChatMessageControllerIntegrationTest extends ControllerIntegrationTestSupp
     }
 
     @Test
-    void createMessage_saves_message_for_active_participant() throws Exception {
+    void getMessages_returns_messages_for_active_participant() throws Exception {
         UserJpaEntity owner = saveUser("chat-owner@test.com", "password123!", "owner", "Owner");
         UserJpaEntity participant = saveUser("chat-participant@test.com", "password123!", "participant", "Participant");
         RoomJpaEntity room = saveRoom("Chat Room", owner);
 
-        mockMvc.perform(post("/api/rooms/{roomCode}/join", room.getRoomCode())
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post("/api/rooms/{roomCode}/join", room.getRoomCode())
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(participant.getId())))
                 .andExpect(status().isOk());
 
-        mockMvc.perform(post("/api/rooms/{roomId}/messages", room.getId())
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(participant.getId()))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "message": "hello chat"
-                                }
-                                """))
-                .andExpect(status().isCreated());
+        chatMessageJpaRepository.save(new ChatMessageJpaEntity("owner", "first message", room, owner));
+        chatMessageJpaRepository.save(new ChatMessageJpaEntity("participant", "second message", room, participant));
 
-        assertThat(chatMessageJpaRepository.count()).isEqualTo(1);
-        ChatMessageJpaEntity savedMessage = chatMessageJpaRepository.findAll().getFirst();
-
-        assertThat(savedMessage.getRoomJpaEntity().getId()).isEqualTo(room.getId());
-        assertThat(savedMessage.getUserJpaEntity().getId()).isEqualTo(participant.getId());
-        assertThat(savedMessage.getSenderNickname()).isEqualTo(participant.getNickname());
-        assertThat(savedMessage.getMessage()).isEqualTo("hello chat");
-        assertThat(savedMessage.getCreatedTime()).isNotNull();
-        assertThat(savedMessage.isDeleted()).isFalse();
+        mockMvc.perform(get("/api/room/{roomId}/messages", room.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(participant.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.messages.length()").value(2))
+                .andExpect(jsonPath("$.messages[0].senderId").value(owner.getId()))
+                .andExpect(jsonPath("$.messages[0].senderNickname").value("owner"))
+                .andExpect(jsonPath("$.messages[0].message").value("first message"))
+                .andExpect(jsonPath("$.messages[0].createdTime").isNotEmpty())
+                .andExpect(jsonPath("$.messages[1].senderId").value(participant.getId()))
+                .andExpect(jsonPath("$.messages[1].senderNickname").value("participant"))
+                .andExpect(jsonPath("$.messages[1].message").value("second message"))
+                .andExpect(jsonPath("$.messages[1].createdTime").isNotEmpty());
     }
 
     @Test
-    void createMessage_requires_authentication() throws Exception {
-        mockMvc.perform(post("/api/rooms/{roomId}/messages", 1L)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "message": "hello"
-                                }
-                                """))
+    void getMessages_requires_authentication() throws Exception {
+        mockMvc.perform(get("/api/room/{roomId}/messages", 1L))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
-    void createMessage_fails_for_non_participant() {
+    void getMessages_fails_for_non_participant() {
         UserJpaEntity owner = saveUser("chat-owner2@test.com", "password123!", "owner2", "Owner2");
         UserJpaEntity outsider = saveUser("chat-outsider@test.com", "password123!", "outsider", "Outsider");
         RoomJpaEntity room = saveRoom("Chat Guard Room", owner);
 
-        assertThatThrownBy(() -> mockMvc.perform(post("/api/rooms/{roomId}/messages", room.getId())
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(outsider.getId()))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "message": "should fail"
-                                }
-                                """)))
+        assertThatThrownBy(() -> mockMvc.perform(get("/api/room/{roomId}/messages", room.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(outsider.getId()))))
                 .isInstanceOf(ServletException.class)
                 .hasRootCauseInstanceOf(RuntimeException.class)
                 .hasMessageContaining("Request processing failed");
-    }
-
-    @Test
-    void createMessage_rejects_blank_message() throws Exception {
-        UserJpaEntity owner = saveUser("chat-owner3@test.com", "password123!", "owner3", "Owner3");
-        RoomJpaEntity room = saveRoom("Blank Chat Room", owner);
-
-        mockMvc.perform(post("/api/rooms/{roomId}/messages", room.getId())
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(owner.getId()))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "message": "   "
-                                }
-                                """))
-                .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/src/test/java/com/ssafy/ssafy_project/chat/adapter/in/websocket/ChatRealtimeIntegrationTest.java
+++ b/src/test/java/com/ssafy/ssafy_project/chat/adapter/in/websocket/ChatRealtimeIntegrationTest.java
@@ -161,6 +161,36 @@ class ChatRealtimeIntegrationTest {
     }
 
     @Test
+    void leaveRoom_disconnects_websocket_session_after_commit() throws Exception {
+        UserJpaEntity owner = saveUser("leave-ws-owner@test.com", "password123!", "leave-ws-owner", "Leave Ws Owner");
+        UserJpaEntity participant = saveUser("leave-ws-participant@test.com", "password123!", "leave-ws-participant", "Leave Ws Participant");
+
+        Long roomId = createRoom(owner.getId(), "Leave WebSocket Room");
+        RoomJpaEntity room = roomJpaRepository.findById(roomId).orElseThrow();
+
+        joinRoom(room.getRoomCode(), participant.getId());
+
+        TestStompSessionHandler participantHandler = new TestStompSessionHandler();
+        StompSession participantSession = connect(createAccessToken(participant.getId()), participantHandler);
+        subscribe(participantSession, roomId);
+
+        mockMvc.perform(post("/api/rooms/{roomId}/leave", roomId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + createAccessToken(participant.getId())))
+                .andExpect(status().isOk());
+
+        boolean disconnected = false;
+        for (int attempt = 0; attempt < 20; attempt++) {
+            if (!participantSession.isConnected()) {
+                disconnected = true;
+                break;
+            }
+            Thread.sleep(100L);
+        }
+
+        assertThat(disconnected).isTrue();
+    }
+
+    @Test
     void deleteMessage_broadcasts_deletion_and_marks_message_deleted() throws Exception {
         UserJpaEntity owner = saveUser("delete-owner@test.com", "password123!", "delete-owner", "Delete Owner");
         Long roomId = createRoom(owner.getId(), "Delete Realtime Room");


### PR DESCRIPTION
# 채팅방 나가기 시 백엔드에서 WebSocket 연결 종료 처리

## 작업 배경

기존에는 사용자가 방에서 나가더라도 이미 맺어진 WebSocket/STOMP 연결이 즉시 정리되지 않았다.

이 상태에서는 다음과 같은 문제가 발생할 수 있다.

- 사용자가 방을 나간 뒤에도 클라이언트가 기존 소켓 연결을 유지할 수 있다.
- 서버 입장에서는 이미 퇴장 처리된 사용자의 세션이 남아 있어 연결 상태와 참가 상태가 어긋날 수 있다.
- 이후 구독/송신 흐름에서 불필요한 예외 처리나 정합성 이슈가 발생할 수 있다.

이번 변경에서는 `방 나가기`가 수행되면 백엔드가 해당 사용자의 WebSocket 세션을 직접 종료하도록 구현했다.

## 변경 사항

### 1. 사용자별 WebSocket 세션 추적 레지스트리 추가

- `WebSocketSessionRegistry`를 추가했다.
- `sessionId -> WebSocketSession`
- `sessionId -> userId`
- `userId -> sessionId 집합`

위 구조로 세션과 사용자를 양방향으로 추적할 수 있도록 구성했다.

추가로 현재 프로젝트에서는 한 사용자가 여러 개의 방에 동시에 참여하는 시나리오를 고려하지 않고 있다.

따라서 이번 구현에서는 세션 정리 단위를 `roomId` 기준으로 세분화하지 않고 `userId` 기준으로 가져갔다.

엄밀히 보면 범위가 넓은 정리 방식이지만, 현 서비스 제약에서는 다른 방 연결을 잘못 끊는 문제가 발생하지 않으며, 퇴장 직후 채팅 연결을 명확하게 정리하는 데 초점을 맞춘 선택이다.

## 2. WebSocket 연결/해제 시 세션 등록 및 정리

- `WebSocketConfig`의 transport decorator에서 connection establish 시 세션을 등록한다.
- connection close 시 세션을 해제한다.
- `WebSocketAuthChannelInterceptor`에서 STOMP `CONNECT` 성공 시 `sessionId`와 `userId`를 바인딩한다.
- STOMP `DISCONNECT` 수신 시 registry에서 세션을 정리한다.

즉, 핸드셰이크 직후 세션 객체를 등록하고, 인증이 완료된 시점에 해당 세션이 어떤 사용자인지 연결한다.

## 3. 방 나가기 이후 사용자 소켓 강제 종료

- `RoomParticipantService.leaveRoom()`에서 퇴장 처리 이후 `closeWebSocketAfterCommit(userId)`를 호출한다.
- 트랜잭션이 활성화된 경우 `afterCommit`에서 세션 종료가 실행되도록 처리했다.
- 트랜잭션이 없는 경우에는 즉시 세션 종료를 수행한다.

이렇게 해서 DB 상의 퇴장 상태가 커밋되기 전에 소켓이 먼저 끊기는 문제를 방지했다.

## 4. 소켓 종료 방식

- `CloseUserWebSocketSessionsPortOut`를 정의하고,
- `WebSocketSessionRegistry`가 이를 구현하도록 연결했다.
- 해당 사용자의 활성 세션을 조회해 `CloseStatus(4000, "ROOM_LEFT")`로 종료한다.

사용자가 여러 탭/창에서 접속한 경우에도 동일 userId로 묶인 세션을 함께 정리할 수 있다.

## 5. 보안 설정 보완

- `/ws` endpoint를 security whitelist에 추가했다.

기존과 동일하게 실제 인증은 HTTP handshake 단계가 아니라 STOMP `CONNECT`에서 처리한다.

## 기대 동작

1. 사용자가 REST API로 방 나가기를 호출한다.
2. 서버가 room participant를 inactive 처리한다.
3. 트랜잭션 커밋 이후 해당 사용자의 WebSocket 세션을 종료한다.
4. 클라이언트는 WebSocket close event를 수신한다.
5. 이후 해당 연결로는 채팅 구독/송신을 지속할 수 없다.

호스트가 방에서 나가는 경우에도 방 종료 처리 후 동일하게 소켓 종료가 수행된다.

## 확인 포인트

- 일반 참가자 방 나가기 후 WebSocket이 종료되는지
- 호스트 방 나가기 후 방 종료와 함께 WebSocket이 종료되는지
- 연결 종료 후 재구독/재송신이 불가능한지
- 이미 종료되었거나 없는 세션에 대해서도 안전하게 정리되는지

## 테스트

- `ChatRealtimeIntegrationTest`에 방 나가기 이후 `StompSession` 연결이 끊어지는 통합테스트를 추가했다.
- 해당 테스트는 방 입장 후 WebSocket 연결을 생성하고, `leave` API 호출 뒤 세션이 `disconnect` 상태로 전환되는지 확인한다.

## 참고 파일

- `src/main/java/com/ssafy/ssafy_project/roomparticipant/application/service/RoomParticipantService.java`
- `src/main/java/com/ssafy/ssafy_project/global/infrastructure/config/WebSocketConfig.java`
- `src/main/java/com/ssafy/ssafy_project/global/infrastructure/websocket/WebSocketAuthChannelInterceptor.java`
- `src/main/java/com/ssafy/ssafy_project/global/infrastructure/websocket/WebSocketSessionRegistry.java`
- `src/main/java/com/ssafy/ssafy_project/roomparticipant/application/port/out/CloseUserWebSocketSessionsPortOut.java`
- `src/main/java/com/ssafy/ssafy_project/global/infrastructure/config/SecurityConfig.java`
